### PR TITLE
Honor 'permissive' setting when creating marc4j reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,27 @@
+Adds a new setting to allow finer-grained control over which `marc4j` reader
+is used to process binary MARC. 
+
+`traject` uses a broadly permissive set of defaults to read binary MARC
+records, which may not always be what you want.  The `permissive` setting sets
+the flag of the same name on the
+(https://github.com/marc4j/marc4j/blob/master/src/org/marc4j/MarcPermissiveStreamReader.java#L164)['permissive'
+reader class] provided by marc4j (which, at the time of writing, controls how
+that reader guesses the encoding of input records.
+
+## Use the "strict" `org.marc4j.MarcStreamReader` class to read MARC21
+
+In situations where you want stricter record processing -- or in case your records can't be processed by the permissive stream reader (paradoxically, `MarcStreamReader` is more forgiving of certain non-standard MARC, e.g. uppercase subfields), you can specify that `traject` should use the `org.marc4j.MarcStreamReader` class:
+
+```ruby 
+settings do 
+    provide 'marc4j_reader.class', 'MarcStreamReader'
+end
+```
+
+## A note about `permissive`
+
+The `marc4j_reader.permissive` setting, which previously existed, is passed
+through to the constructor of the `MarcPermissiveStreamReader` class, and does
+not effect which class is used to read MARC21 input.  If you set both this parameter and the `marc4j_reader.class` parameter, the `permissive` setting will be ignored.
+
+

--- a/lib/traject/marc4j_reader.rb
+++ b/lib/traject/marc4j_reader.rb
@@ -81,6 +81,7 @@ class Traject::Marc4JReader
 
     # Convenience
     java_import org.marc4j.MarcPermissiveStreamReader
+    java_import org.marc4j.MarcStreamReader
     java_import org.marc4j.MarcXmlReader
 
   end
@@ -112,11 +113,16 @@ class Traject::Marc4JReader
   def create_marc_reader!
     case input_type
     when "binary"
-      permissive = settings["marc4j_reader.permissive"].to_s == "true"
+      the_stream = input_stream.to_inputstream
+      if settings['marc4j_reader.class'] == 'MarcStreamReader'
+          MarcStreamReader.new(the_stream, specified_source_encoding)
+      else
+        permissive = settings["marc4j_reader.permissive"].to_s == "true"
 
-      # #to_inputstream turns our ruby IO into a Java InputStream
-      # third arg means 'convert to UTF-8, yes'
-      MarcPermissiveStreamReader.new(input_stream.to_inputstream, permissive, true, specified_source_encoding)
+        # #to_inputstream turns our ruby IO into a Java InputStream
+        # third arg means 'convert to UTF-8, yes'
+        MarcPermissiveStreamReader.new(the_stream, permissive, true, specified_source_encoding)
+      end
     when "xml"
       MarcXmlReader.new(input_stream.to_inputstream)
     else


### PR DESCRIPTION
Current implementation always creates an instance of MarcPermissiveStreamReader, which, regardless of the 'permissive' flag, uses different code to process records.  For those who want the stricter reader, it should be possible to create an ordinary MarcStreamReader.